### PR TITLE
increase nodejs timeout

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -10,7 +10,7 @@ namespace: merative
 name: spm_toolbox
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.1.2
+version: 1.1.3
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/nodejs/tasks/main.yml
+++ b/roles/nodejs/tasks/main.yml
@@ -22,9 +22,15 @@
       ansible.builtin.debug:
         msg: https://nodejs.org/dist/{{ nodejs_version }}/node-{{ nodejs_version }}-linux-x64.tar.gz
 
-    - name: Download and unarchive NodeJS
+    - name: Download NodeJS tarball
+      get_url:
+        url: https://nodejs.org/dist/{{ nodejs_version }}/node-{{ nodejs_version }}-linux-x64.tar.gz
+        dest: /tmp/node-{{ nodejs_version }}-linux-x64.tar.gz
+        timeout: 300  # Seconds
+
+    - name: Unarchive NodeJS
       unarchive:
-        src: https://nodejs.org/dist/{{ nodejs_version }}/node-{{ nodejs_version }}-linux-x64.tar.gz
+        src: /tmp/node-{{ nodejs_version }}-linux-x64.tar.gz
         dest: /usr/local/
         remote_src: true
         mode: 0755


### PR DESCRIPTION
## Summary
Added a timeout to this after encountering an issue where the node download would time out even though the server was available:
https://github.com/spm-devops/support-hub/issues/23816

## Test
https://spmdevops-team-apollo.jenkins.commops.merative.com/view/Provisioner/job/DevOps-Jenkins-ProvisionerWrapper/1054/console

Bootstrapped machine using this branch
![image](https://github.com/user-attachments/assets/28a1efeb-76d5-4d84-b91a-8176b0bf8a08)
