### PR TITLE
SPM-143690 Update nodejs default to v20

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ env.python_ver }}
-          # cache: 'pip'
+
       # remove android and dotnet to gain more spaces for oracle installation
       - name: Maximize build space
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ env.python_ver }}
-          cache: 'pip'
+          # cache: 'pip'
       # remove android and dotnet to gain more spaces for oracle installation
       - name: Maximize build space
         run: |

--- a/roles/nodejs/defaults/main.yml
+++ b/roles/nodejs/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-nodejs_version: v18.12.0
+nodejs_version: v20.9.0
 
 # Common
 profiled_path: /opt/profile.d


### PR DESCRIPTION
Update the default node to v20 as that is a requirement on all our VMs now (qualys raises vulnerabiltiies otherwise).
We can pass in whatever version we want as a parameter  but best to update this at source.

## Changes
- update nodejs default
- remove cache from the workflow file that does our molecule tests.
https://github.com/merative/spm-toolbox/actions/runs/15532450727
Getting an error for cache: only way around it from what I can find is to remove, or use a different version of python. Could be intermittent in theory but the molecule tests take 2.5m without it, don't think we need cache here (previous passing builds take anything from 40s to 4m so not sure what the time savings is).

## Test

The provisionerwrapper is passing in this version by default and it is working:
https://spmdevops-team-apollo.jenkins.commops.merative.com/job/DevOps-Jenkins-ProvisionerWrapper/1510/parameters/
